### PR TITLE
Problem: C does not have namespaces

### DIFF
--- a/go/libmockdiscgo.go
+++ b/go/libmockdiscgo.go
@@ -3,8 +3,8 @@ package main
 import "C"
 import "fmt"
 
-//export DiscoverEndpoints
-func DiscoverEndpoints(url, key string) *C.char {
+//export ZDiscgoDiscoverEndpoints
+func ZDiscgoDiscoverEndpoints(url, key string) *C.char {
 	return C.CString(fmt.Sprintf("inproc://%s-%s", url, key))
 }
 

--- a/src/zdiscgoplugin.c
+++ b/src/zdiscgoplugin.c
@@ -42,7 +42,7 @@ zdiscgoplugin_new (char *libpath)
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-pedantic"
-    self->discover = (char * (*)(go_str, go_str)) dlsym(self->handle, "DiscoverEndpoints");
+    self->discover = (char * (*)(go_str, go_str)) dlsym(self->handle, "ZDiscgoDiscoverEndpoints");
     if (!self->discover)
         return NULL;
 #pragma GCC diagnostic pop 


### PR DESCRIPTION
Since C has no concepts of namespaces or packages, we should probably prefix the Go function we are importing so that it has less chance of colliding with something.